### PR TITLE
ant_native: Fix compilation errors for MSM8992/4 (non CAF)

### DIFF
--- a/src/bt-vendor_vfs/Android.mk
+++ b/src/bt-vendor_vfs/Android.mk
@@ -20,15 +20,19 @@ LOCAL_CFLAGS := -g -c -W -Wall -O2
 
 # needed to pull in the header file for libbt-vendor.so
 BDROID_DIR:= system/bt
-QCOM_DIR:= $(call project-path-for,bt-vendor)/libbt-vendor
+QCOM_DIR:= $(call project-path-for,bt-vendor)
 
 # Added hci/include to give access to the header for the libbt-vendorso interface.
 LOCAL_C_INCLUDES := \
    $(LOCAL_PATH)/src/common/inc \
    $(LOCAL_PATH)/$(ANT_DIR)/inc \
    $(BDROID_DIR)/hci/include \
-   $(QCOM_DIR)/include \
+   $(QCOM_DIR)/libbt-vendor/include
 
+ifneq ($(filter msm8994 msm8992,$(TARGET_BOARD_PLATFORM)),)
+LOCAL_C_INCLUDES += \
+   $(QCOM_DIR)/msm8992/libbt-vendor/include
+endif
 
 ifeq ($(BOARD_ANT_WIRELESS_DEVICE),"qualcomm-uart")
 LOCAL_C_INCLUDES += \


### PR DESCRIPTION
Change-Id: Ifea98d11a378ba7ea18b68fece450ee79a8197f7